### PR TITLE
Fix bugs in generated pkgconfig file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ if(MSVC)
 endif()
 
 
-add_project_dependency(Eigen3 REQUIRED)
+add_project_dependency(Eigen3 REQUIRED PKG_CONFIG_REQUIRES eigen3)
 add_project_dependency(Boost REQUIRED)
 add_subdirectory(src)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -26,6 +26,8 @@ else()
   target_link_libraries(gram_savitzky_golay PUBLIC ${BOOST_LIBRARIES})
 endif()
 
+pkg_config_append_libs(gram_savitzky_golay)
+
 set_target_properties(gram_savitzky_golay PROPERTIES SOVERSION ${PROJECT_VERSION})
 
 install(TARGETS gram_savitzky_golay


### PR DESCRIPTION
Hello, these are some fixes that I made to use this project as a dependency using meson (i.e. through pkgconfig):
- Update jrl-cmakemodules which includes https://github.com/jrl-umi3218/jrl-cmakemodules/pull/335
- use the new `PKG_CONFIG_REQUIRES` to cause `eigen3` to be included in the `Requires` line of the generated pkgconfig. This is necessary so that the include directives for Eigen headers work (their include path is non standard).
- use `pkg_config_append_libs` to ensure that `-lgram_savitzky_golay` is included in the `Libs` line of the generated pkgconfig. This is necessary so that the exported symbols are available to the linker.